### PR TITLE
gluon-xlat464: initial commit

### DIFF
--- a/package/gluon-xlat464-clat/Makefile
+++ b/package/gluon-xlat464-clat/Makefile
@@ -1,0 +1,38 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-xlat464-clat
+PKG_VERSION:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include ../gluon.mk
+
+
+define Package/gluon-xlat464-clat
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  TITLE:=Support for using IPv4 over IPv6-only networks using xlat464
+  DEPENDS:=+gluon-core +kmod-nat46
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Compile
+	$(call GluonSrcDiet,./luasrc,$(PKG_BUILD_DIR)/luadest/)
+endef
+
+define Package/gluon-xlat464-clat/install
+	$(CP) $(PKG_BUILD_DIR)/luadest/* $(1)/
+	$(INSTALL_DIR) $(1)/lib/netifd/proto
+	$(INSTALL_BIN) ./files/xlat464clat.sh $(1)/lib/netifd/proto/xlat464clat.sh
+endef
+
+define Package/gluon-xlat464-clat/postinst
+#!/bin/sh
+$(call GluonCheckSite,check_site.lua)
+endef
+
+$(eval $(call BuildPackage,gluon-xlat464-clat))
+

--- a/package/gluon-xlat464-clat/check_site.lua
+++ b/package/gluon-xlat464-clat/check_site.lua
@@ -1,0 +1,2 @@
+need_string(in_domain({'clat_range'}))
+

--- a/package/gluon-xlat464-clat/files/xlat464clat.sh
+++ b/package/gluon-xlat464-clat/files/xlat464clat.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+# Copyright 2018 Vincent Wiemann <vincent.wiemann@ironai.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2
+# as published by the Free Software Foundation
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+CTR=/proc/net/nat46/control
+
+
+[ -n "$INCLUDE_ONLY" ] || {
+  . /lib/functions.sh
+  . ../netifd-proto.sh
+  init_proto "$@"
+}
+
+
+proto_xlat464clat_init_config() {
+  proto_config_add_string "zone"
+  proto_config_add_string "zone4"
+  proto_config_add_string "local_style"
+  proto_config_add_string "local_v4"
+  proto_config_add_string "local_v6"
+  proto_config_add_string "local_ea_len"
+  proto_config_add_string "local_psid"
+  proto_config_add_boolean "local_fmr_flag"
+  proto_config_add_string "remote_style"
+  proto_config_add_string "remote_v4"
+  proto_config_add_string "remote_v6"
+  proto_config_add_string "remote_ea_len"
+  proto_config_add_string "remote_psid"
+  proto_config_add_string "ip4table"
+  proto_config_add_boolean "debug"
+  available=1
+  no_device=1
+}
+
+
+proto_xlat464clat_setup() {
+  local config="$1"
+  local clat_cfg="config ${config}"
+  local local_style
+  local local_v4
+  local local_v6
+  local local_ea_len
+  local local_psid
+  local local_fmr
+  local remote_style
+  local remote_v4
+  local remote_v6
+  local remote_ea_len
+  local remote_psid
+  local zone
+  local zone4
+  local ip4table
+
+
+  config_load network
+
+  config_get		ip4table	"${config}" "ip4table"
+  config_get		zone		"${config}" "zone"
+  config_get		zone4		"${config}" "zone4"
+  config_get_bool	debug		"${config}" "debug" 0
+  config_get		local_style	"${config}" "local_style"
+  config_get		local_v4	"${config}" "local_v4"
+  config_get		local_v6	"${config}" "local_v6"
+  config_get		local_ea_len	"${config}" "local_ea_len"
+  config_get		local_psid	"${config}" "local_psid_offset"
+  config_get_bool	local_fmr	"${config}" "local_fmr_flag" 0
+  config_get		remote_style	"${config}" "remote_style"
+  config_get		remote_v4	"${config}" "remote_v4"
+  config_get		remote_v6	"${config}" "remote_v6"
+  config_get		remote_ea_len	"${config}" "remote_ea_len"
+  config_get		remote_psid	"${config}" "remote_psid_offset"
+
+
+  zone="${zone:-wan}"
+  zone4="${zone4:-lan}"
+  local_v6="${local_v6:-fd00:13:37:13:37::/96}"
+  remote_v4="${remote_v4:-0.0.0.0/0}"
+
+  [ $debug -ne 0 ] && clat_cfg="$clat_cfg debug 1"
+  [ ${local_fmr} -ne 0 ] && clat_cfg="$clat_cfg local.fmr-flag 1"
+
+  clat_cfg="${clat_cfg} local.style ${local_style:-RFC6052} local.v4 ${local_v4:-192.168.1.0/24} local.v6 ${local_v6}"
+  clat_cfg="${clat_cfg} local.ea-len ${local_ea_len:-0} local.psid-offset ${local_psid:-0}"
+  clat_cfg="${clat_cfg} remote.style ${remote_style:-RFC6052} remote.v4 ${remote_v4} remote.v6 ${remote_v6:-64:ff9b::/96}"
+  clat_cfg="${clat_cfg} remote.ea-len ${remote_ea_len:-0} remote.psid-offset ${remote_psid:-0}"
+
+  # create nat46 interface
+  echo "add ${config}" > ${CTR}
+
+  # configure nat46
+  echo "${clat_cfg}" > ${CTR}
+
+  [ "${ip4table}" ] && ip -4 rule add from ${local_v4} lookup ${ip4table}
+
+  proto_init_update "${config}" 1
+
+	  # add routes
+	  case "${local_v6}" in
+	    *:*/*)
+	      proto_add_ipv6_route "${local_v6%%/*}" "${local_v6##*/}"
+	    ;;
+	    *:*)
+	      proto_add_ipv6_route "${local_v6%%/*}" "128"
+	    ;;
+	  esac
+
+	  case "${remote_v4}" in
+	    *.*/*)
+	      proto_add_ipv4_route "${remote_v4%%/*}" "${remote_v4##*/}" "" "" 2048
+	    ;;
+	    *.*)
+	      proto_add_ipv4_route "${remote_v4%%/*}" "32" "" "" 2048
+	    ;;
+	  esac
+
+	proto_add_data
+	[ "${zone}" != "-" ] && json_add_string zone "${zone}"
+
+	json_add_array firewall
+	  # if forwarding within "zone" and between zone<->zone4 is allowed you can set zone = "-"
+	  if [ "${zone}" != "-" ]; then
+	  	json_add_object ""
+	  		json_add_string type rule
+	  		json_add_string family inet6
+	  		json_add_string proto all
+	  		json_add_string direction in
+			json_add_string dest "${zone}"
+			json_add_string src "${zone}"
+	  		json_add_string src_ip "$local_v6"
+	  		json_add_string target ACCEPT
+	  	json_close_object
+		# if a forwarding between zone and zone4 exists (e.g. lan<->wan) you can set zone4 = "-"
+	  	if [ "${zone4}" != "-" ]; then
+		  	json_add_object ""
+		  		json_add_string type rule
+		  		json_add_string family inet
+		  		json_add_string proto all
+		  		json_add_string direction out
+				json_add_string dest "${zone}"
+				[ "$remote_v4" != "0.0.0.0/0" ] && json_add_string dest_ip "$remote_v4"
+				json_add_string src "${zone4}"
+		  		json_add_string src_ip "$local_v4"
+		  		json_add_string target ACCEPT
+		  	json_close_object
+	  	fi
+	  fi
+
+	json_close_array
+
+	proto_close_data
+
+  proto_send_update "$config"
+}
+
+
+proto_xlat464clat_teardown() {
+  local config="$1"
+  echo "del ${config}" > ${CTR}
+}
+
+
+[ -n "$INCLUDE_ONLY" ] || {
+  add_protocol xlat464clat
+}
+

--- a/package/gluon-xlat464-clat/luasrc/lib/gluon/upgrade/450-gluon-xlat464-clat
+++ b/package/gluon-xlat464-clat/luasrc/lib/gluon/upgrade/450-gluon-xlat464-clat
@@ -1,0 +1,39 @@
+#!/usr/bin/lua
+local site = require 'gluon.site'
+local sysconfig = require 'gluon.sysconfig'
+local uci = require('simple-uci').cursor()
+
+local f = io.open("/etc/iproute2/rt_tables", "r")
+if f then 
+  if not f:read("*a"):find("10\tclat") then
+    f:close()
+    f = io.open("/etc/iproute2/rt_tables", "a")
+    if f then
+      f:write("\n10\tclat\n")
+    end
+  end
+  f:close()
+end
+
+
+local plat_prefix = uci:get('network', 'plat', 'local_v6') or "64:ff9b::/96"
+
+uci:set('network', 'local_node', 'ip4table', 'clat')
+
+local appendix = sysconfig.primary_mac:gsub('%:', '')
+appendix = string.format('%x:%x:%x', tonumber(appendix:sub(1, 4), 16), tonumber(appendix:sub(5, 8), 16), tonumber(appendix:sub(9, 12), 16))
+local clat_prefix = string.format('%s%s::/96', site.clat_range():gsub(':/.+', ''), appendix)
+
+uci:delete('network', 'clat')
+uci:section('network', 'interface', 'clat', {
+	proto = 'xlat464clat',
+	local_v4 = site.prefix4(),
+	local_v6 = clat_prefix,
+	remote_v6 = plat_prefix,
+	zone = "mesh",
+	zone4 = "local_client",
+	ip4table = "clat",
+})
+uci:save('network')
+
+

--- a/package/gluon-xlat464-plat/Makefile
+++ b/package/gluon-xlat464-plat/Makefile
@@ -1,0 +1,38 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-xlat464-plat
+PKG_VERSION:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include ../gluon.mk
+
+
+define Package/gluon-xlat464-plat
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  TITLE:=Support for sharing WAN IPv4 over IPv6-only networks using xlat464
+  DEPENDS:=+gluon-core +kmod-nat46 +kmod-ipt-nat6
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Compile
+	$(call GluonSrcDiet,./luasrc,$(PKG_BUILD_DIR)/luadest/)
+endef
+
+define Package/gluon-xlat464-plat/install
+	$(CP) $(PKG_BUILD_DIR)/luadest/* $(1)/
+	$(INSTALL_DIR) $(1)/lib/netifd/proto
+	$(INSTALL_BIN) ./files/xlat464plat.sh $(1)/lib/netifd/proto/xlat464plat.sh
+endef
+
+define Package/gluon-xlat464-plat/postinst
+#!/bin/sh
+$(call GluonCheckSite,check_site.lua)
+endef
+
+$(eval $(call BuildPackage,gluon-xlat464-plat))
+

--- a/package/gluon-xlat464-plat/check_site.lua
+++ b/package/gluon-xlat464-plat/check_site.lua
@@ -1,0 +1,3 @@
+need_string(in_domain({'plat_range'}))
+
+

--- a/package/gluon-xlat464-plat/files/xlat464plat.sh
+++ b/package/gluon-xlat464-plat/files/xlat464plat.sh
@@ -1,0 +1,172 @@
+#!/bin/sh
+# Copyright 2018 Vincent Wiemann <vincent.wiemann@ironai.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2
+# as published by the Free Software Foundation
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+CTR=/proc/net/nat46/control
+
+
+[ -n "$INCLUDE_ONLY" ] || {
+  . /lib/functions.sh
+  . ../netifd-proto.sh
+  init_proto "$@"
+}
+
+
+proto_xlat464plat_init_config() {
+  proto_config_add_bool "debug"
+  proto_config_add_string "local_v4"
+  proto_config_add_string "local_v6"
+  proto_config_add_string "nat66addr"
+  proto_config_add_string "tunlink"
+  proto_config_add_string "zone"
+  proto_config_add_string "zone6"
+  available=1
+  no_device=1
+}
+
+
+proto_xlat464plat_setup() {
+  local config="$1"
+
+  local plat_cfg="config ${config}"
+  local debug
+  local local_v4
+  local local_v6
+  local nat66addr
+  local tunlink
+  local zone
+  local zone6
+
+  config_load network
+  config_get_bool	debug		"${config}" "debug" 0
+  config_get		local_v4	"${config}" "local_v4"
+  config_get		local_v6	"${config}" "local_v6"
+  config_get		nat66addr	"${config}" "nat66addr"
+  config_get		tunlink		"${config}" "tunlink"
+  config_get		zone		"${config}" "zone"
+  config_get		zone6		"${config}" "zone6"
+
+  nat66addr="${nat66addr:-fddd:c:1a4c:1a4c:1a4c:1a4c:c000:8}"
+  local_v4="${local_v4:-0.0.0.0/0}"
+  local_v6="${local_v6:-64:ff9b::/96}"
+  tunlink="${tunlink:-wan}"
+  zone="${zone:-wan}"
+  zone6="${zone6:-lan}"
+
+
+  ( proto_add_host_dependency "$config" "${local_v4%%/*}" "${tunlink}" )
+
+  if [ ${debug} -ne 0 ]; then
+    plat_cfg="${plat_cfg} debug 1"
+  fi
+
+  plat_cfg="${plat_cfg} local.style RFC6052 local.v6 ${local_v6} local.v4 ${local_v4}"
+  plat_cfg="${plat_cfg} remote.style NONE remote.v4 192.0.0.8/32 remote.v6 ${nat66addr}/128"
+
+  echo "add ${config}" > ${CTR}
+  echo "${plat_cfg}" > ${CTR}
+
+
+  proto_init_update "${config}" 1
+
+  proto_add_ipv6_address "${local_v6%%:/*}c000:1" "128"
+  proto_add_ipv6_route "${local_v6%%/*}" "${local_v6##*/}"
+  proto_add_ipv4_route "192.0.0.8" "32"
+
+	proto_add_data
+	[ "$zone" != "-" ] && json_add_string zone "$zone"
+
+	json_add_array firewall
+		# this fw3 IPv6 SNAT rule is broken
+		json_add_object ""
+			json_add_string type nat
+			json_add_string target SNAT
+			json_add_string family ipv6
+			json_add_string snat_ip "${nat66addr}"
+		json_close_object
+
+	  if [ "$zone" != "-" ]; then
+	  	json_add_object ""
+	  		json_add_string type rule
+	  		json_add_string family inet
+	  		json_add_string proto all
+	  		json_add_string direction in
+			json_add_string dest "$zone"
+			json_add_string src "$zone"
+	  		json_add_string src_ip 192.0.0.8
+	  		json_add_string target ACCEPT
+	  	json_close_object
+	  fi
+
+	  if [ "$zone6" != "-" ]; then
+		# deny access to 192.168.0.0/16
+	  	json_add_object ""
+	  		json_add_string type rule
+	  		json_add_string family ipv6
+	  		json_add_string proto all
+	  		json_add_string direction out
+			json_add_string dest "$zone"
+			json_add_string src "${zone6}"
+	  		json_add_string dest_ip "${local_v6%%:/*}c0a8::/112"
+	  		json_add_string target DROP
+	  	json_close_object
+		# deny access to 172.16.0.0/12
+		json_add_object ""
+	  		json_add_string type rule
+	  		json_add_string family ipv6
+	  		json_add_string proto all
+	  		json_add_string direction out
+			json_add_string dest "$zone"
+			json_add_string src "${zone6}"
+	  		json_add_string dest_ip "${local_v6%%:/*}ac10::/108"
+	  		json_add_string target DROP
+	  	json_close_object
+		# deny access to 10.0.0.0/8
+	  	json_add_object ""
+	  		json_add_string type rule
+	  		json_add_string family ipv6
+	  		json_add_string proto all
+	  		json_add_string direction out
+			json_add_string dest "$zone"
+			json_add_string src "${zone6}"
+	  		json_add_string dest_ip "${local_v6%%:/*}a00::/104"
+	  		json_add_string target DROP
+	  	json_close_object
+		# allow access to everything else
+	  	json_add_object ""
+	  		json_add_string type rule
+	  		json_add_string family ipv6
+	  		json_add_string proto all
+	  		json_add_string direction out
+			json_add_string dest "$zone"
+			json_add_string src "${zone6}"
+	  		json_add_string dest_ip "${local_v6}"
+	  		json_add_string target ACCEPT
+	  	json_close_object
+	  fi
+	json_close_array
+
+	proto_close_data
+
+  proto_send_update "${config}"
+}
+
+
+proto_xlat464plat_teardown() {
+  local config="$1"
+  echo "del ${config}" > ${CTR}
+}
+
+
+[ -n "$INCLUDE_ONLY" ] || {
+  add_protocol xlat464plat
+}
+

--- a/package/gluon-xlat464-plat/luasrc/lib/gluon/upgrade/440-gluon-xlat464-plat
+++ b/package/gluon-xlat464-plat/luasrc/lib/gluon/upgrade/440-gluon-xlat464-plat
@@ -1,0 +1,35 @@
+#!/usr/bin/lua
+local site = require 'gluon.site'
+local sysconfig = require 'gluon.sysconfig'
+local uci = require('simple-uci').cursor()
+
+
+local appendix = sysconfig.primary_mac:gsub('%:', '')
+appendix = string.format('%x:%x:%x', tonumber(appendix:sub(1, 4), 16), tonumber(appendix:sub(5, 8), 16), tonumber(appendix:sub(9, 12), 16))
+local plat_prefix = string.format('%s%s::/96', site.plat_range():gsub(':/.+', ''), appendix)
+
+
+uci:delete('network', 'plat')
+uci:section('network', 'interface', 'plat', {
+	auto = false,
+	local_v6 = plat_prefix,
+	proto = 'xlat464plat',
+	tunlink = 'wan',
+	zone = 'wan',
+	zone6 = 'mesh',
+})
+uci:save('network')
+
+
+-- LEDE/OpenWrt fw3 IPv6 SNAT seems to be broken in the current version (says „snat_ip is unknown“). Append SNAT rule manually:
+io.open('/etc/firewall.xlat464plat', 'w'):write("#!/bin/sh\nip6tables -t nat -A POSTROUTING -o plat -j SNAT --to fddd:c:1a4c:1a4c:1a4c:1a4c:c000:8\n")
+uci:delete('firewall', 'nat66')
+uci:section('firewall', 'include', 'nat66', {
+	path = '/etc/firewall.xlat464plat',
+	family = 'ipv6',
+})
+uci:save('firewall')
+
+
+
+


### PR DESCRIPTION
This package adds netifd protos for 464XLAT CLAT and PLAT configuration to offer IPv4 over IPv6 to clients.
At the moment the CLAT must be reconfigured manually to use it with a PLAT other than its own.

- [x] Create initial working firewall and routing configuration
- [x] (PLAT) Configure a static address for PLAT
- [ ] (PLAT) Put interface in mesh instead of wan-zone?

